### PR TITLE
Incorporate unmerged PRs from upstream

### DIFF
--- a/chef-ruby-shadow.gemspec
+++ b/chef-ruby-shadow.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |spec|
     spec.files << file.chomp
   end
   spec.homepage              = 'https://github.com/apalmblad/ruby-shadow'
-  spec.name                  = 'ruby-shadow'
-  spec.required_ruby_version = ['>= 1.8']
+  spec.name                  = 'chef-ruby-shadow'
+  spec.required_ruby_version = ['>= 3.0']
   spec.summary               = '*nix Shadow Password Module'
-  spec.version               = '2.5.1'
+  spec.version               = '3.0.0'
   spec.license  = "Unlicense"
 end

--- a/extconf.rb
+++ b/extconf.rb
@@ -1,7 +1,7 @@
 #                                          -*- ruby -*-
 # extconf.rb
 #
-# Modified at: <1999/8/19 06:38:55 by ttate> 
+# Modified at: <1999/8/19 06:38:55 by ttate>
 #
 
 require 'mkmf'
@@ -14,7 +14,7 @@ $CFLAGS = case RUBY_VERSION
           else; ''
           end
 
-implementation = case CONFIG['host_os']
+implementation = case RbConfig::CONFIG['host_os']
                  when /linux/i; 'shadow'
                  when /sunos|solaris/i; 'shadow'
                  when /freebsd|mirbsd|netbsd|openbsd/i; 'pwd'

--- a/pwd/shadow.c
+++ b/pwd/shadow.c
@@ -56,8 +56,8 @@ static VALUE convert_pw_struct( struct passwd *entry )
 {
   /* Hmm. Why custom pw_change instead of sp_lstchg? */
   return rb_struct_new(rb_sPasswdEntry,
-         rb_tainted_str_new2(entry->pw_name), /* sp_namp */
-         rb_tainted_str_new2(entry->pw_passwd), /* sp_pwdp, encryped password */
+         rb_str_new2(entry->pw_name), /* sp_namp */
+         rb_str_new2(entry->pw_passwd), /* sp_pwdp, encryped password */
          Qnil, /* sp_lstchg, date when the password was last changed (in days since Jan 1, 1970) */
          Qnil, /* sp_min, days that password must stay same */
          Qnil, /* sp_max, days until password changes. */
@@ -66,7 +66,7 @@ static VALUE convert_pw_struct( struct passwd *entry )
          INT2FIX(difftime(entry->pw_change, 0) / (24*60*60)), /* pw_change */
          INT2FIX(difftime(entry->pw_expire, 0) / (24*60*60)), /* sp_expire */
          Qnil, /* sp_flag */
-         rb_tainted_str_new2(entry->pw_class), /* sp_loginclass, user access class */
+         rb_str_new2(entry->pw_class), /* sp_loginclass, user access class */
          NULL);
 }
 

--- a/shadow/shadow.c
+++ b/shadow/shadow.c
@@ -31,11 +31,11 @@ static VALUE rb_sGroupEntry;
 static VALUE rb_eFileLock;
 
 
-static VALUE convert_pw_struct( struct spwd *entry ) 
+static VALUE convert_pw_struct( struct spwd *entry )
 {
   return rb_struct_new(rb_sPasswdEntry,
-		      rb_tainted_str_new2(entry->sp_namp),
-		      rb_tainted_str_new2(entry->sp_pwdp),
+		      rb_str_new2(entry->sp_namp),
+		      rb_str_new2(entry->sp_pwdp),
 		      INT2FIX(entry->sp_lstchg),
 		      INT2FIX(entry->sp_min),
 		      INT2FIX(entry->sp_max),


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Incorporate the following PRs:
* https://github.com/apalmblad/ruby-shadow/pull/31 (breakage starting in Ruby 3.2)
* https://github.com/apalmblad/ruby-shadow/pull/29 (taint functions removed in Ruby 3.2: https://bugs.ruby-lang.org/issues/16131)

Bumped the version to 3.0.0 and changed the gem name to `chef-ruby-shadow` (this fork already existed) as the above PRs are approaching 3 years old.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
