### PR TITLE
Remove extraneous logic

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -7,13 +7,6 @@
 require 'mkmf'
 require 'rbconfig'
 
-$CFLAGS = case RUBY_VERSION
-          when /^1\.9/; '-DRUBY19'
-          when /^2\./; '-DRUBY19'
-          when /^3\./; '-DRUBY19'
-          else; ''
-          end
-
 implementation = case RbConfig::CONFIG['host_os']
                  when /linux/i; 'shadow'
                  when /sunos|solaris/i; 'shadow'
@@ -42,7 +35,7 @@ when 'shadow'
 
   if ok
     if !have_func("sgetspent")
-      $CFLAGS += ' -DSOLARIS'
+      $CFLAGS = '-DSOLARIS'
     end
   end
 when 'pwd'

--- a/pwd/shadow.c
+++ b/pwd/shadow.c
@@ -23,11 +23,7 @@
 #include "rubyio.h"
 #endif
 
-#ifdef RUBY19
 #define file_ptr(x) (x)->stdio_file
-#else
-#define file_ptr(x) (x)->f
-#endif
 
 static VALUE rb_mShadow;
 static VALUE rb_mPasswd;

--- a/shadow/shadow.c
+++ b/shadow/shadow.c
@@ -15,12 +15,7 @@
 #include "rubyio.h"
 #endif
 
-#ifdef RUBY19
 #define file_ptr(x) rb_io_stdio_file(x)
-#else
-#define file_ptr(x) (x)->f
-#endif
-
 #define NUM_FIELDS 10
 
 static VALUE rb_mShadow;


### PR DESCRIPTION
Every version of Ruby released for at least the last decade was set to use the -DRUBY19 flag. This commit sets the behavior in the flag as the default.

## Description
I was attempting to build ruby-shadow on Ruby 4.0.0-preview2 and hit the same issue that's been worked around since Ruby 1.9.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
